### PR TITLE
Add multiple author metadata support

### DIFF
--- a/cli/pom.xml
+++ b/cli/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>info.jab.pml</groupId>
         <artifactId>prompt-markup-language</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>info.jab.pml</groupId>
     <artifactId>cli</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>cli</name>
 

--- a/documentation/MAINTENANCE.md
+++ b/documentation/MAINTENANCE.md
@@ -25,7 +25,7 @@ Can you update the current changelog for 0.5.0 comparing git commits in relation
 # Prompt to provide a release changelog
 Can you update the current changelog for 0.7.0 comparing git commits in relation to 0.6.0 tag. Use  @https://keepachangelog.com/en/1.1.0/  rules
 
-./mvnw versions:set -DnewVersion=0.7.0
+./mvnw versions:set -DnewVersion=0.8.0-SNAPSHOT
 ./mvnw versions:commit
 ## Note: Refactor a bit more to include all pom.xml
 ./mvnw clean verify

--- a/jacoco-report-aggregated/pom.xml
+++ b/jacoco-report-aggregated/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>info.jab.pml</groupId>
         <artifactId>prompt-markup-language</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>info.jab.pml</groupId>
     <artifactId>prompt-markup-language</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>prompt-markup-language</name>

--- a/schema/pom.xml
+++ b/schema/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>info.jab.pml</groupId>
         <artifactId>prompt-markup-language</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>info.jab.pml</groupId>
     <artifactId>schema</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>schema</name>
 

--- a/schema/src/main/resources/pml.xsd
+++ b/schema/src/main/resources/pml.xsd
@@ -38,6 +38,7 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element ref="author" minOccurs="0"/>
+                <xs:element ref="authors" minOccurs="0"/>
                 <xs:element ref="version" minOccurs="0"/>
                 <xs:element ref="license" minOccurs="0"/>
                 <xs:element ref="title" minOccurs="0"/>
@@ -47,6 +48,13 @@
     </xs:element>
 
     <xs:element name="author" type="xs:string"/>
+    <xs:element name="authors">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="author" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
     <xs:element name="version" type="xs:string"/>
     <xs:element name="license" type="xs:string"/>
     <xs:element name="title" type="xs:string" />

--- a/schema/src/test/java/info/jab/pml/model/SchemaPMLValidationTest.java
+++ b/schema/src/test/java/info/jab/pml/model/SchemaPMLValidationTest.java
@@ -46,6 +46,7 @@ class SchemaPMLValidationTest {
             "/pml/pml-java25-installation-v3.xml",
             "/pml/pml-java25-installation-v4.xml",
             "/pml/pml-java25-installation-v5.xml",
+            "/pml/pml-multiple-authors.xml",
             "/pml/113-java-maven-documentation.xml"
         };
     }

--- a/schema/src/test/resources/pml/pml-multiple-authors.xml
+++ b/schema/src/test/resources/pml/pml-multiple-authors.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<prompt>
+    <metadata>
+        <author>Juan Antonio</author>
+        <authors>
+            <author>Breña</author>
+            <author>Moral</author>
+        </authors>
+    </metadata>
+    <goal>
+        Validate multiple metadata authors.
+    </goal>
+</prompt>

--- a/types/pom.xml
+++ b/types/pom.xml
@@ -7,13 +7,13 @@
     <parent>
         <groupId>info.jab.pml</groupId>
         <artifactId>prompt-markup-language</artifactId>
-        <version>0.7.0</version>
+        <version>0.8.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>info.jab.pml</groupId>
     <artifactId>types</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>types</name>
 


### PR DESCRIPTION
## Summary
- Add transitional metadata support for both `author` and `authors/author`
- Bump modules to `0.8.0-SNAPSHOT`
- Add schema validation coverage for multiple authors

## Tests
- `mvn -pl schema test`